### PR TITLE
Added missing variable declaration for downcode

### DIFF
--- a/parameterize.js
+++ b/parameterize.js
@@ -91,7 +91,7 @@ Downcoder.Initialize = function()
     Downcoder.regex = new RegExp('[' + Downcoder.chars + ']|[^' + Downcoder.chars + ']+','g') ;
 }
  
-downcode= function( slug )
+var downcode = function( slug )
 {
     Downcoder.Initialize() ;
     var downcoded =""


### PR DESCRIPTION
The latest version throws an error at line 94 due to a missing variable declaration for the downcode function. This pull request adds the missing variable declaration.