### PR TITLE
Fix undefined variable error under strict mode

### DIFF
--- a/parameterize.js
+++ b/parameterize.js
@@ -180,7 +180,7 @@ var downcode = function(slug){
     return downcoded;
 }
 
-parameterize = function(s, num_chars, delimiter) {
+var parameterize = function(s, num_chars, delimiter) {
     delimiter = delimiter || '-'
 
     // changes, e.g., "Petty theft" to "petty_theft"


### PR DESCRIPTION
When trying to use this module in a vite project, we got a `ReferenceError`, due to this module running under `"use strict";` mode, similar to this error:

```
/home/mpeveler/parameterize.js:185
parameterize = function(s, num_chars, delimiter) {
             ^

ReferenceError: parameterize is not defined
    at Object.<anonymous> (/home/mpeveler/parameterize.js:185:14)
    at Module._compile (node:internal/modules/cjs/loader:1165:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1219:10)
    at Module.load (node:internal/modules/cjs/loader:1043:32)
    at Function.Module._load (node:internal/modules/cjs/loader:878:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47
```

This PR fixes that error by making sure that `parameterize` is defined using `var`, similar to the other variables in  the file.