### PR TITLE
Fix assign-to-undeclared in strict mode

### DIFF
--- a/parameterize.js
+++ b/parameterize.js
@@ -180,7 +180,7 @@ var downcode = function(slug){
     return downcoded;
 }
 
-parameterize = function(s, num_chars, delimiter) {
+var parameterize = function(s, num_chars, delimiter) {
     delimiter = delimiter || '-'
 
     // changes, e.g., "Petty theft" to "petty_theft"


### PR DESCRIPTION
Repair strict mode violation to allow parameterize to be imported as an esmodule by e.g. webpack with `output { module: true }`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#assigning_to_undeclared_variables